### PR TITLE
Add payload to executeRule()

### DIFF
--- a/github-webhook.js
+++ b/github-webhook.js
@@ -183,11 +183,14 @@ function handleRules (logStream, rules, event) {
 
     eventsDebug('Matched rule for %s', eventStr)
 
-    var clone = Object.assign(process.env, payload);
+    var addEnvProperties = ['ref'];
+    for(prop in payload) {
+        if (addEnvProperties.indexOf(prop) !== -1) {
+            Object.defineProperty(process.env, 'gw_' + prop, {value: payload[prop]})
+        }
+    }
 
-    console.log(clone)
-
-    cp = spawn(exec.shift(), exec, { env: clone })
+    cp = spawn(exec.shift(), exec, { env: process.env })
     
     cp.on('error', function (err) {
       return eventsDebug('Error executing command [%s]: %s', rule.exec, err.message)

--- a/github-webhook.js
+++ b/github-webhook.js
@@ -162,7 +162,7 @@ function prefixStream (stream, prefix) {
 
 
 function handleRules (logStream, rules, event) {
-  function executeRule (rule) {
+  function executeRule (rule, payload) {
     if (rule.executing === true) {
       rule.queued = true // we're busy working on this rule, queue up another run
       return
@@ -183,7 +183,11 @@ function handleRules (logStream, rules, event) {
 
     eventsDebug('Matched rule for %s', eventStr)
 
-    cp = spawn(exec.shift(), exec, { env: process.env })
+    var clone = Object.assign(process.env, payload);
+
+    console.log(clone)
+
+    cp = spawn(exec.shift(), exec, { env: clone })
     
     cp.on('error', function (err) {
       return eventsDebug('Error executing command [%s]: %s', rule.exec, err.message)
@@ -218,7 +222,7 @@ function handleRules (logStream, rules, event) {
     if (!matchme(event.payload, rule.match))
       return
 
-    executeRule(rule)
+    executeRule(rule, event.payload)
   })
 }
 

--- a/test.js
+++ b/test.js
@@ -91,12 +91,12 @@ test('valid request triggers rule', function (t) {
             , {   // should trigger this event
                   event : eventType
                 , match : 'some == github'
-                , exec  : 'echo "w00t!" > ' + tmpfile
+                , exec  : 'echo $gw_ref > ' + tmpfile
               }
           ]
       }
     , server    = webhook(options)
-    , obj       = { some: 'github', object: 'with', properties: true }
+    , obj       = { some: 'github', object: 'with', properties: true, ref: 'refs/heads/dev' }
     , json      = JSON.stringify(obj)
     , id        = '123abc'
 
@@ -109,65 +109,7 @@ test('valid request triggers rule', function (t) {
     setTimeout(function () {
       fs.readFile(tmpfile, 'utf8', function (err, data) {
         t.error(err)
-        t.equal(data, 'w00t!\n')
-      })
-      fs.exists(tmpfile + '2', function (exists) {
-        t.notOk(exists, 'does not exist, didn\'t trigger second event')
-      })
-    }, 100)
-  })
-
-  supertest(server)
-    .post('/webhook')
-    .set('X-Hub-Signature', signBlob('foofaa', json))
-    .set('X-Github-Event', eventType)
-    .set('X-Github-Delivery', id)
-    .send(json)
-    .expect('Content-Type', /json/)
-    .expect(200)
-    .end(function(err){
-      t.error(err)
-    })
-
-})
-
-test('valid request triggers rule 2', function (t) {
-  t.plan(5)
-
-  var tmpfile   = __dirname + '/__test_data.' + Math.random()
-    , eventType = 'issues'
-    , options   = {
-          port   : 0
-        , path   : '/webhook'
-        , secret : 'foofaa'
-        , rules  : [
-              {   // should not trigger this event
-                  event : eventType
-                , match : 'some == xxgithub'
-                , exec  : [ 'sh', '-c', 'echo "w00t!" > ' + tmpfile + '2' ]
-              }
-            , {   // should trigger this event
-                  event : eventType
-                , match : 'some == github'
-                , exec  : 'echo $some > ' + tmpfile
-              }
-          ]
-      }
-    , server    = webhook(options)
-    , obj       = {ref: 'refs/heads/master', before: 'a250b47f054d1d2d4a5ce484635c8b4b365c5d36', after: 'b411c26d3db3df0eb24027cace219f3ceaeb1c3b', compare: 'https://github.com/AttestationLegale/site-bo/compare/a250b47f054d...b411c26d3db3'}
-    , json      = JSON.stringify(obj)
-    , id        = '123abc'
-
-  t.on('end', function () {
-    fs.unlink(tmpfile, function () {})
-  })
-
-  server.webhookHandler.on(eventType, function (event) {
-    t.deepEqual(event, { event: eventType, id: id, payload: obj, url: '/webhook' })
-    setTimeout(function () {
-      fs.readFile(tmpfile, 'utf8', function (err, data) {
-        t.error(err)
-        t.equal(data, 'github\n')
+        t.equal(data, 'refs/heads/dev\n')
       })
       fs.exists(tmpfile + '2', function (exists) {
         t.notOk(exists, 'does not exist, didn\'t trigger second event')

--- a/test.js
+++ b/test.js
@@ -130,3 +130,61 @@ test('valid request triggers rule', function (t) {
     })
 
 })
+
+test('valid request triggers rule 2', function (t) {
+  t.plan(5)
+
+  var tmpfile   = __dirname + '/__test_data.' + Math.random()
+    , eventType = 'issues'
+    , options   = {
+          port   : 0
+        , path   : '/webhook'
+        , secret : 'foofaa'
+        , rules  : [
+              {   // should not trigger this event
+                  event : eventType
+                , match : 'some == xxgithub'
+                , exec  : [ 'sh', '-c', 'echo "w00t!" > ' + tmpfile + '2' ]
+              }
+            , {   // should trigger this event
+                  event : eventType
+                , match : 'some == github'
+                , exec  : 'echo $some > ' + tmpfile
+              }
+          ]
+      }
+    , server    = webhook(options)
+    , obj       = {ref: 'refs/heads/master', before: 'a250b47f054d1d2d4a5ce484635c8b4b365c5d36', after: 'b411c26d3db3df0eb24027cace219f3ceaeb1c3b', compare: 'https://github.com/AttestationLegale/site-bo/compare/a250b47f054d...b411c26d3db3'}
+    , json      = JSON.stringify(obj)
+    , id        = '123abc'
+
+  t.on('end', function () {
+    fs.unlink(tmpfile, function () {})
+  })
+
+  server.webhookHandler.on(eventType, function (event) {
+    t.deepEqual(event, { event: eventType, id: id, payload: obj, url: '/webhook' })
+    setTimeout(function () {
+      fs.readFile(tmpfile, 'utf8', function (err, data) {
+        t.error(err)
+        t.equal(data, 'github\n')
+      })
+      fs.exists(tmpfile + '2', function (exists) {
+        t.notOk(exists, 'does not exist, didn\'t trigger second event')
+      })
+    }, 100)
+  })
+
+  supertest(server)
+    .post('/webhook')
+    .set('X-Hub-Signature', signBlob('foofaa', json))
+    .set('X-Github-Event', eventType)
+    .set('X-Github-Delivery', id)
+    .send(json)
+    .expect('Content-Type', /json/)
+    .expect(200)
+    .end(function(err){
+      t.error(err)
+    })
+
+})


### PR DESCRIPTION
L'objectif de cette PR est de pouvoir utiliser des informations envoyées par Github dans nos scripts de déploiement (ex: la référence de la branch, le tag, ...)